### PR TITLE
Refactor embed flow and introduce EditModal for inline editing

### DIFF
--- a/embed_templates/championship_template.json
+++ b/embed_templates/championship_template.json
@@ -9,9 +9,6 @@
       "footer": {
         "text": "Atenciosamente, a equipe Marvel Rivals Brazuka"
       },
-      "image": {
-        "url": "https://media.discordapp.net/attachments/1337263839896666152/1344813393592324126/image.png?ex=67c2ef52&is=67c19dd2&hm=1c42af9f7af9268faf14d61b7ab78f252681b17f1e5fbcdb5d1f268e649c015b&=&format=webp&quality=lossless"
-      },
       "fields": [
         {
           "id": 120613196,

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ import json
 import discord
 from discord import app_commands
 from discord.ext import commands
-from discord.ui import View, Button
+from discord.ui import Modal, TextInput, View, Button
 
 import os
 
@@ -154,39 +154,50 @@ async def embed(
         async def confirm(self, interaction: discord.Interaction, button: Button):
             self.value = True
             self.action = "confirm"
-            await interaction.response.edit_message(content="✅ Embed confirmado. Enviando...", view=None)
+            await interaction.response.edit_message(content="✅ Embed enviado com sucesso!", view=None)
             self.stop()
 
         @discord.ui.button(label="Não", style=discord.ButtonStyle.red)
         async def cancel(self, interaction: discord.Interaction, button: Button):
             self.value = False
             self.action = "cancel"
-            await interaction.response.edit_message(content="❌ Envio cancelado. Caso queira, use o comando novamente.",
-                                                    view=None)
+            await interaction.response.edit_message(content="❌ Envio do embed foi cancelado.", view=None)
             self.stop()
 
         @discord.ui.button(label="Editar", style=discord.ButtonStyle.blurple)
         async def edit(self, interaction: discord.Interaction, button: Button):
             self.value = False
             self.action = "edit"
-            await interaction.response.edit_message(content="🔄 Reabrindo o prompt para edição. Aguarde...", view=None)
+            await interaction.response.send_modal(EditModal(template, notificacao, titulo, descricao, canal, imagem))
+
             self.stop()
+
+    class EditModal(Modal, title="Editar Informações do Embed"):
+        def __init__(self, template, notificacao, titulo, descricao, canal, imagem):
+            super().__init__()
+            self.add_item(TextInput(label="Template", default=template, required=True))
+            self.add_item(
+                TextInput(label="Notificação", default=notificacao, required=True, style=discord.TextStyle.paragraph))
+            self.add_item(TextInput(label="Título", default=titulo, required=True))
+            self.add_item(
+                TextInput(label="Descrição", default=descricao, required=True, style=discord.TextStyle.paragraph))
+            self.add_item(TextInput(label="Canal ID", default=str(canal.id), required=True))
+            self.add_item(TextInput(label="Imagem (URL)", default=imagem if imagem else "", required=False))
+
+        async def on_submit(self, interaction: discord.Interaction):
+            new_template = self.children[0].value
+            new_notificacao = self.children[1].value
+            new_titulo = self.children[2].value
+            new_descricao = self.children[3].value
+            new_canal_id = int(self.children[4].value)
+            new_imagem = self.children[5].value if self.children[5].value else None
+
+            new_canal = interaction.guild.get_channel(new_canal_id)
+
+            await embed(interaction, new_template, new_notificacao, new_titulo, new_descricao, new_canal, new_imagem)
 
     view = ConfirmView()
     await interaction.followup.send("Você deseja enviar este embed?", view=view, ephemeral=True)
-
-    await view.wait()
-
-    if view.action == "confirm":
-        await canal.send(content=template_data["content"], embed=embed)
-        await interaction.followup.send("✅ Embed enviado com sucesso!", ephemeral=True)
-    elif view.action == "cancel":
-        await interaction.followup.send("❌ Envio do embed foi cancelado.", ephemeral=True)
-    elif view.action == "edit":
-        await interaction.followup.send(
-            content="🔄 Por favor, reenvie o comando `/embed` com os novos valores que deseja alterar.",
-            ephemeral=True,
-        )
 
 
 #######################


### PR DESCRIPTION
### Description

This pull request refactors the embed flow by introducing the `EditModal` for real-time inline editing, replacing the previous manual edit prompt. It also streamlines the embed submission workflow, removes the unused `image` field from `championship_.json`, and enhances user feedback for confirm/cancel actions.