### PR TITLE
Fix button disabling logic in `update_buttons`

### DIFF
--- a/main.py
+++ b/main.py
@@ -122,7 +122,7 @@ async def embed(interaction: discord.Interaction):
         def update_buttons(self):
             for child in self.children:
                 if child.label == "Definir Mensagem de Notificação *":
-                    child.disabled = self.embed_data["template"] == "patchnote"
+                    child.disabled = self.embed_data["template"] == "patchnote" and self.embed_data["template"] is None
                 elif child.label != "Definir Template *":
                     child.disabled = self.embed_data["template"] is None
 


### PR DESCRIPTION
### Description

This pull request addresses an issue with the `update_buttons` method where buttons were incorrectly being disabled when the mode was "patchnote." An additional check is now implemented to ensure the mode is not `None` before disabling the button, preventing unintended behaviors.