### PR TITLE
Fix button disabling logic in update_buttons method

### DIFF
--- a/main.py
+++ b/main.py
@@ -122,7 +122,7 @@ async def embed(interaction: discord.Interaction):
         def update_buttons(self):
             for child in self.children:
                 if child.label == "Definir Mensagem de Notificação *":
-                    child.disabled = self.embed_data["template"] == "patchnote" and self.embed_data["template"] is None
+                    child.disabled = self.embed_data["template"] == "patchnote" or self.embed_data["template"] is None
                 elif child.label != "Definir Template *":
                     child.disabled = self.embed_data["template"] is None
 


### PR DESCRIPTION
### Description
This pull request addresses a logic issue in the `update_buttons` method. The prior condition incorrectly required both states to be `"patchnote"` and `None` simultaneously, which is logically impossible. The fix ensures the button is properly disabled when the state is either `"patchnote"` or `None`, resulting in the intended behavior.

### Changes
- Corrected the button disabling logic in the `update_buttons` method.