### PR TITLE
Enable "Enviar" button validation for 'notificacao' field

### DIFF
--- a/main.py
+++ b/main.py
@@ -133,10 +133,9 @@ async def embed(interaction: discord.Interaction):
                 elif child.label.__contains__("Cancelar"):
                     continue
                 elif child.label.__contains__("Enviar"):
-                    child.disabled = (self.embed_data["template"] is None
-                                      or self.embed_data["canal_envio"] is None
-                                      or self.embed_data["titulo"] is None
-                                      or self.embed_data["descricao"] is None)
+                    child.disabled = self.embed_data["template"] is None or self.embed_data["canal_envio"] is None or \
+                                     self.embed_data["titulo"] is None or self.embed_data["descricao"] is None or \
+                                     self.embed_data["notificacao"] is None
                 elif child.label.__contains__("Imagem"):
                     child.label = "Editar Imagem" if self.embed_data.get("imagem") else "Adicionar Imagem"
                     child.disabled = self.embed_data["template"] is None


### PR DESCRIPTION
### Description

This pull request ensures the "Enviar" button remains disabled until the 'notificacao' field, alongside all other required fields, is correctly filled. Previously, the button's conditions did not account for the ‘notificacao’ field.
